### PR TITLE
fix: add optional message field to WorkItemStatusUpdate schema

### DIFF
--- a/backend/app/api/v1/schemas.py
+++ b/backend/app/api/v1/schemas.py
@@ -1,3 +1,4 @@
+from email import message
 import json
 
 from typing import Optional, Dict, Any
@@ -31,7 +32,7 @@ class WorkqueueInformation(BaseModel):
     completed: int
     failed: int
     pending_user_action: int
-    
+
 class WorkItemCreate(BaseModel):
     data: Dict = {}
     reference: Optional[str] = ""
@@ -42,6 +43,7 @@ class WorkItemUpdate(BaseModel):
 
 class WorkItemStatusUpdate(BaseModel):
     status: enums.WorkItemStatus
+    message: Optional[str] = None
 
 class WorkItemRead(BaseModel):
     id: int


### PR DESCRIPTION
## Problem
The `WorkItemStatusUpdate` schema was missing the `message` field, causing the server to ignore error messages sent by the client when calling `item.fail("message")`.

## Solution
Added optional `message` field to the `WorkItemStatusUpdate` schema. No changes needed to the endpoint since it already uses `model_dump(exclude_unset=True)`.