### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the Automation Server project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-07-08
+
+### Security
+
+- **Dependency upgrades across all components** patching ~135 advisories rooted in stale lockfiles ([344b99b](https://github.com/odense-rpa/automation-server/commit/344b99b)):
+  - Backend: h11 0.16.0 (request smuggling, CVE-2025-43859), python-multipart 0.0.32 (arbitrary file write, CVE-2026-24486), starlette 1.3.1 via FastAPI 0.139.0 (7 CVEs), urllib3 2.7.0 (decompression-bomb DoS)
+  - Worker: gitpython 3.1.50 (4 RCE-class CVEs in clone/config paths), urllib3 2.7.0, requests 2.34.2
+  - Frontend: axios 1.16.x (25 advisories), form-data boundary randomness fix (critical), vite 5.4.21, tar chain
+  - Website: shell-quote 1.9.0 (command injection), babel/fast-uri/ws updates
+- **Docker base images**: node 20 (EOL) → 24, nginx 1.25 → 1.30, uv image pinned to 0.11.28 (was `:latest`); `.env*` excluded from worker image via `.dockerignore`
+
+### Internal
+
+- Migrated to trunk-based development: `main` is the only long-lived branch, protected with required CI checks; releases are marked by `v*` tags
+- Added CI workflow running backend tests/lint and frontend lint/build on all pull requests
+- Added nightly Docker build workflow
+
+---
+
 ## [0.4.0] - 2026-05-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Automation Server
 
-[![Version](https://img.shields.io/badge/version-0.4.0-blue.svg)](https://github.com/odense-rpa/automation-server)
+[![Version](https://img.shields.io/badge/version-0.4.1-blue.svg)](https://github.com/odense-rpa/automation-server)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/status-beta-orange.svg)](https://github.com/odense-rpa/automation-server/issues)
 [![Documentation](https://img.shields.io/badge/docs-live-blue.svg)](https://odense-rpa.github.io/automation-server/)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -71,7 +71,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 
 # Add metadata labels
 LABEL maintainer="your-email@example.com" \
-      version="0.4.0" \
+      version="0.4.1" \
       description="Automation Server Backend"
 
 # Use exec form for proper signal handling

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automation_server_backend"
-version = "0.4.0"
+version = "0.4.1"
 description = "The Automation Server Backend - run api services and manages the database"
 requires-python = ">=3.13"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "automation-server-backend"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # For development, use: docker compose up  (auto-applies docker-compose.override.yml)
 
 x-worker-common: &worker-template
-  image: ghcr.io/odense-rpa/ats-worker:v0.4.0
+  image: ghcr.io/odense-rpa/ats-worker:v0.4.1
   environment:
     ATS_URL: ${ATS_URL:-http://api:8000}
     ATS_TOKEN: ${ATS_TOKEN}
@@ -36,7 +36,7 @@ services:
     restart: unless-stopped
 
   api:
-    image: ghcr.io/odense-rpa/ats-backend:v0.4.0
+    image: ghcr.io/odense-rpa/ats-backend:v0.4.1
     depends_on:
       db:
         condition: service_healthy
@@ -50,7 +50,7 @@ services:
     restart: unless-stopped
 
   frontend:
-    image: ghcr.io/odense-rpa/ats-frontend:v0.4.0
+    image: ghcr.io/odense-rpa/ats-frontend:v0.4.1
     ports:
       - "80"
     environment:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -41,7 +41,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
 
 # Add metadata labels
 LABEL maintainer="miwn@odense.dk" \
-      version="0.4.0" \
+      version="0.4.1" \
       description="Automation Server Frontend"
 
 # Start nginx

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automationserver-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -54,7 +54,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 
 # Add metadata labels
 LABEL maintainer="miwn@odense.dk" \
-      version="0.4.0" \
+      version="0.4.1" \
       description="Automation Server Worker"
 
 # Run the main Python script

--- a/worker/build-standard.sh
+++ b/worker/build-standard.sh
@@ -2,6 +2,6 @@
 # Build standard worker image
 
 echo "Building standard worker image..."
-docker build --target worker -t automation-server-worker:0.4.0 .
+docker build --target worker -t automation-server-worker:0.4.1 .
 echo "Standard worker image built successfully!"
-echo "Tagged as: automation-server-worker:0.4.0"
+echo "Tagged as: automation-server-worker:0.4.1"

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automation_server_worker"
-version = "0.4.0"
+version = "0.4.1"
 description = "Provides a worker for the automation server. Runs python scripts with playwright included"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/worker/uv.lock
+++ b/worker/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "automation-server-worker"
-version = "0.4.0"
+version = "0.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
Patch release: security dependency upgrades (~135 advisories, incl. h11 request smuggling, python-multipart arbitrary file write, gitpython RCE-class, critical form-data fix), Docker base image updates, changelog entry, version bump to 0.4.1.

Tag `v0.4.1` will be pushed after merge to trigger Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)