### PR TITLE
feat: add git_options field for process git clone control

### DIFF
--- a/backend/alembic/versions/d41f7c9e2b10_add_git_options_to_process.py
+++ b/backend/alembic/versions/d41f7c9e2b10_add_git_options_to_process.py
@@ -1,0 +1,30 @@
+"""Add git_options column to process
+
+Revision ID: d41f7c9e2b10
+Revises: 0dc924f3af5c
+Create Date: 2026-07-08 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d41f7c9e2b10"
+down_revision: Union[str, None] = "0dc924f3af5c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "process",
+        sa.Column("git_options", sa.String(), nullable=True, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("process", "git_options")

--- a/backend/app/api/v1/schemas.py
+++ b/backend/app/api/v1/schemas.py
@@ -1,8 +1,9 @@
+import shlex
 from datetime import datetime
 from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 from cronsim import CronSim, CronSimError
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from typing_extensions import Self
 
 from app import enums
@@ -81,10 +82,24 @@ class ProcessCreate(BaseModel):
     requirements: Optional[str] = ""
     target_type: enums.TargetTypeEnum
     target_source: Optional[str] = ""
+    git_options: Optional[str] = ""
     target_credentials_id: Optional[int] = None
     credentials_id: Optional[int] = None
     workqueue_id: Optional[int] = None
     requirements: Optional[str] = ""
+
+    @field_validator("git_options")
+    @classmethod
+    def validate_git_options(cls, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return value
+        if "\n" in value or "\r" in value:
+            raise ValueError("git_options must be a single line")
+        try:
+            shlex.split(value)
+        except ValueError as e:
+            raise ValueError(f"git_options is not parseable: {e}") from e
+        return value
 
 
 class ProcessUpdate(ProcessCreate):

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -60,6 +60,7 @@ class Process(Base, table=True):
 
     target_type: enums.TargetTypeEnum | None = None
     target_source: typing.Optional[str] = ""
+    git_options: typing.Optional[str] = ""
 
     target_credentials_id: typing.Optional[int] | None = Field(
         default=None, foreign_key="credential.id"

--- a/backend/tests/test_process.py
+++ b/backend/tests/test_process.py
@@ -96,6 +96,81 @@ async def test_create_process(session: AsyncSession, client: AsyncClient):
     assert data["description"] == "New description"
 
 
+async def test_create_process_with_git_options(
+    session: AsyncSession, client: AsyncClient
+):
+    await generate_basic_data(session)
+
+    response = await client.post(
+        "/processes/",
+        json={
+            "name": "Process",
+            "description": "New description",
+            "workqueue_id": 1,
+            "target_type": "python",
+            "target_source": "Test url",
+            "git_options": "--branch=dev --depth=1",
+            "target_credentials_id": None,
+            "credentials_id": None,
+        },
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["git_options"] == "--branch=dev --depth=1"
+
+    process = await session.get(models.Process, data["id"])
+    assert process.git_options == "--branch=dev --depth=1"
+
+
+async def test_update_process_git_options(session: AsyncSession, client: AsyncClient):
+    await generate_basic_data(session)
+
+    response = await client.put(
+        "/processes/1",
+        json={
+            "name": "Process",
+            "description": "Process for unittest",
+            "workqueue_id": 1,
+            "target_type": "python",
+            "target_source": "Test url",
+            "git_options": "--branch=release/1.0",
+            "target_credentials_id": 1,
+            "credentials_id": 1,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["git_options"] == "--branch=release/1.0"
+
+    process = await session.get(models.Process, 1)
+    assert process.git_options == "--branch=release/1.0"
+
+
+async def test_create_process_rejects_invalid_git_options(
+    session: AsyncSession, client: AsyncClient
+):
+    await generate_basic_data(session)
+
+    for bad_options in ["--branch='unclosed", "--depth=1\n--branch=dev"]:
+        response = await client.post(
+            "/processes/",
+            json={
+                "name": "Process",
+                "description": "New description",
+                "workqueue_id": 1,
+                "target_type": "python",
+                "target_source": "Test url",
+                "git_options": bad_options,
+                "target_credentials_id": None,
+                "credentials_id": None,
+            },
+        )
+
+        assert response.status_code == 422
+
+
 async def test_delete_process(session: AsyncSession, client: AsyncClient):
     await generate_basic_data(session)
 

--- a/docs/guides/setup-a-process.md
+++ b/docs/guides/setup-a-process.md
@@ -20,6 +20,7 @@ Navigate to **Processes** in the sidebar and click **+ Create**. Fill in the det
 
 - **Name** — a human-readable label for the automation
 - **Git repository** — the URL of the repository containing your automation code
+- **Git options** — optional extra arguments for `git clone`, e.g. `--branch=dev --depth=1` to run from a specific branch or tag. Leave empty to clone the default branch.
 - **Requirements** — leave as `python` unless your automation needs specific packages
 
 ![Creating a process](/img/guide-setup-create-process.png)

--- a/frontend/src/components/ProcessForm.vue
+++ b/frontend/src/components/ProcessForm.vue
@@ -74,6 +74,21 @@
       </div>
     </div>
 
+    <!-- Git Options Field (Python Only) -->
+    <div class="flex items-center" v-if="editedProcess.target_type == 'python'">
+      <label for="git_options" class="w-1/5 font-semibold">Git options</label>
+      <div class="w-full">
+        <input
+          type="text"
+          class="input input-bordered w-full"
+          v-model="editedProcess.git_options"
+          id="git_options"
+          placeholder="--branch=dev --depth=1"
+        />
+        <small class="text-base-content/60 block mt-1">Extra arguments passed to git clone</small>
+      </div>
+    </div>
+
     <!-- Git Credentials Field (Python Only) -->
     <div class="flex items-center" v-if="editedProcess.target_type == 'python'">
       <label for="target_credentials_id" class="w-1/5 font-semibold">Git credentials</label>

--- a/frontend/src/views/CreateProcessView.vue
+++ b/frontend/src/views/CreateProcessView.vue
@@ -24,6 +24,7 @@ export default {
         description: '',
         target_type: 'python',
         target_source: '',
+        git_options: '',
         target_credentials_id: null,
         credentials_id: null,
         workqueue_id: null,

--- a/worker/main.py
+++ b/worker/main.py
@@ -94,6 +94,7 @@ if __name__ == "__main__":
                                     repo_url=process["target_source"],
                                     username=username,
                                     token=token,
+                                    git_options=process.get("git_options"),
                                     script_env={
                                         "ATS_URL": automationserver_url,
                                         "ATS_TOKEN": automationserver_token,

--- a/worker/runners/python.py
+++ b/worker/runners/python.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+import shlex
 import tempfile
 import logging
 import sys
@@ -64,6 +65,7 @@ def run_python(
     token: Optional[str] = None,
     script_env: Optional[Dict[str, str]] = None,
     script_args: Optional[List[str]] = None,
+    git_options: Optional[str] = None,
 ) -> Tuple[Optional[str], Optional[str], int]:
     """Clones repo, sets up env with 'uv', installs deps, and runs main.py.
 
@@ -73,6 +75,8 @@ def run_python(
         token (Optional[str]): Personal Access Token for authentication (if needed).
         script_env (Optional[Dict[str, str]]): Environment variables to pass when running main.py.
         script_args (Optional[List[str]]): Command-line arguments to pass to main.py.
+        git_options (Optional[str]): Extra arguments appended to `git clone`,
+            e.g. "--branch=dev --depth=1".
 
     Returns:
         Tuple[str | None, str | None, int]: (stdout, stderr, return code).
@@ -85,12 +89,23 @@ def run_python(
         if username and token:
             repo_url = repo_url.replace("https://", f"https://{username}:{token}@")
 
+        multi_options = ["--recurse-submodules"]
+        if git_options:
+            try:
+                multi_options += shlex.split(git_options)
+            except ValueError as e:
+                logging.error(f"Invalid git options {git_options!r}: {e}")
+                return None, None, 1
+
         # Clone the repo
-        logging.info(f"Cloning repository into {temp_path}...")
+        logging.info(f"Cloning repository into {temp_path} (options: {multi_options})...")
         try:
-            git.Repo.clone_from(repo_url, temp_path, multi_options=["--recurse-submodules"])
+            git.Repo.clone_from(repo_url, temp_path, multi_options=multi_options)
         except git.exc.GitCommandError as e:
-            logging.error(f"Git clone failed: {e}")
+            message = str(e)
+            if token:
+                message = message.replace(token, "***")
+            logging.error(f"Git clone failed: {message}")
             return None, None, 1
 
         # Initialize virtual environment using 'uv'


### PR DESCRIPTION
## Summary

Implements #17 — processes get an optional **git_options** field passed straight to `git clone`, e.g. `--branch=dev --depth=1`. Covers branch/tag selection, shallow clones, and future git needs without one field per option. Empty field = current behavior (default branch).

Design discussion in #17: a free-form options field was chosen over a dedicated branch field/dropdown since the platform already grants users arbitrary code execution by design (they control the repo), so restricting clone arguments adds no security — only friction.

## Changes

- **Backend**: `git_options` column on `process` (Alembic migration, nullable, default `''`), exposed in `ProcessCreate`/`ProcessUpdate` with save-time `shlex` validation (rejects unparseable quoting and multi-line input).
- **Worker**: `run_python()` splits the options with `shlex` and appends them to the hardcoded `--recurse-submodules`. Invalid ref/options fail the session with the git error in the log. Clone failure logs now scrub the access token from the error message (previously leaked creds-in-URL).
- **Frontend**: "Git options" text input on the process form (Python targets), placeholder `--branch=dev --depth=1`.
- **Docs**: field documented in the setup-a-process guide.

## Compatibility

- Old worker + new backend: extra field ignored.
- New worker + old backend: `process.get("git_options")` → `None`.
- Existing processes: empty field, behavior unchanged.

## Testing

- Backend: 160 tests pass (3 new: create/update roundtrip, invalid-options 422).
- Frontend: eslint + build clean.
- Worker (manual, local git repo): `--branch=dev` runs branch code, empty options run default branch, bogus branch fails session with clear git error, unparseable options fail before clone.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)