### PR TITLE
feat: add workqueue auto-clean of old workitems

### DIFF
--- a/backend/alembic/versions/e7c1f0a2b9d4_add_auto_clean_max_age_days_to_workqueue.py
+++ b/backend/alembic/versions/e7c1f0a2b9d4_add_auto_clean_max_age_days_to_workqueue.py
@@ -1,0 +1,30 @@
+"""Add auto_clean_max_age_days to workqueue
+
+Revision ID: e7c1f0a2b9d4
+Revises: d41f7c9e2b10
+Create Date: 2026-07-08 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e7c1f0a2b9d4"
+down_revision: Union[str, None] = "d41f7c9e2b10"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workqueue",
+        sa.Column("auto_clean_max_age_days", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workqueue", "auto_clean_max_age_days")

--- a/backend/app/api/v1/schemas.py
+++ b/backend/app/api/v1/schemas.py
@@ -32,6 +32,7 @@ class WorkqueueInformation(BaseModel):
     name: str = Field(min_length=1)
     description: str
     enabled: bool
+    auto_clean_max_age_days: Optional[int] = None
     new: int
     in_progress: int
     completed: int

--- a/backend/app/api/v1/schemas.py
+++ b/backend/app/api/v1/schemas.py
@@ -17,12 +17,14 @@ class WorkqueueUpdate(BaseModel):
     name: str = Field(min_length=1)
     description: str
     enabled: bool
+    auto_clean_max_age_days: Optional[int] = Field(default=None, ge=1)
 
 
 class WorkqueueCreate(BaseModel):
     name: str = Field(min_length=1)
     description: str
     enabled: bool
+    auto_clean_max_age_days: Optional[int] = Field(default=None, ge=1)
 
 
 class WorkqueueInformation(BaseModel):

--- a/backend/app/api/v1/workqueue_router.py
+++ b/backend/app/api/v1/workqueue_router.py
@@ -88,6 +88,7 @@ async def get_workqueues_information(
                 name=queue.name,
                 description=queue.description,
                 enabled=queue.enabled,
+                auto_clean_max_age_days=queue.auto_clean_max_age_days,
                 new=counts.get(enums.WorkItemStatus.NEW, 0),
                 in_progress=counts.get(enums.WorkItemStatus.IN_PROGRESS, 0),
                 completed=counts.get(enums.WorkItemStatus.COMPLETED, 0),

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -44,6 +44,7 @@ class Workqueue(Base, table=True):
     name: str = Field(min_length=1)
     description: typing.Optional[str]
     enabled: bool = Field(default=True)
+    auto_clean_max_age_days: int | None = Field(default=None)
 
     deleted: bool = False
 

--- a/backend/app/database/repository/workqueue_repository.py
+++ b/backend/app/database/repository/workqueue_repository.py
@@ -55,6 +55,16 @@ class AbstractWorkqueueRepository(AbstractRepository[Workqueue]):
     ) -> list[WorkItem]:
         raise NotImplementedError
 
+    @abc.abstractmethod
+    async def get_auto_clean_workqueues(self) -> list[Workqueue]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def clear_terminal_items_older_than(
+        self, workqueue_id: int, days: int
+    ) -> int:
+        raise NotImplementedError
+
 
 class WorkqueueRepository(DatabaseRepository[Workqueue]):
     def __init__(self, session: AsyncSession) -> None:
@@ -138,6 +148,30 @@ class WorkqueueRepository(DatabaseRepository[Workqueue]):
 
         await self.session.execute(query)
         await self.session.commit()
+
+    async def get_auto_clean_workqueues(self) -> list[Workqueue]:
+        """Get non-deleted workqueues with auto-clean enabled."""
+        query = select(Workqueue).where(
+            Workqueue.deleted == False,  # noqa: E712
+            Workqueue.auto_clean_max_age_days.isnot(None),
+        )
+        return list(await self.session.scalars(query))
+
+    async def clear_terminal_items_older_than(
+        self, workqueue_id: int, days: int
+    ) -> int:
+        """Delete completed/failed workitems not updated within the given number of days."""
+        cutoff_date = datetime.now() - timedelta(days=days)
+        query = delete(WorkItem).where(
+            WorkItem.workqueue_id == workqueue_id,
+            WorkItem.status.in_(
+                [enums.WorkItemStatus.COMPLETED, enums.WorkItemStatus.FAILED]
+            ),
+            WorkItem.updated_at < cutoff_date,
+        )
+        result = await self.session.execute(query)
+        await self.session.commit()
+        return result.rowcount
 
     async def get_by_reference(
         self,

--- a/backend/app/scheduler/core.py
+++ b/backend/app/scheduler/core.py
@@ -6,7 +6,7 @@ This module contains the refactored AutomationScheduler class using the modular 
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -41,6 +41,7 @@ class AutomationScheduler:
         """Initialize the scheduler."""
         self.processor_registry = None
         self.dispatcher = None
+        self._last_auto_clean: datetime | None = None
 
     async def run_background_task(self):
         """Background task that runs the scheduler in a loop."""
@@ -103,6 +104,13 @@ class AutomationScheduler:
             await session_service.reschedule_orphaned_sessions()
             await session_service.flush_dangling_sessions()
             await incident_service.create_incidents_for_new_failures()
+
+            # Auto-clean workqueues at most once per hour
+            if self._last_auto_clean is None or (
+                datetime.now() - self._last_auto_clean
+            ) >= timedelta(hours=1):
+                await workqueue_service.auto_clean_workqueues()
+                self._last_auto_clean = datetime.now()
 
             # Dispatch pending sessions first
             await self.dispatcher.dispatch_all_pending()

--- a/backend/app/services/workqueue_service.py
+++ b/backend/app/services/workqueue_service.py
@@ -1,9 +1,12 @@
+import logging
 from typing import Optional
 
 from app.api.v1.schemas import PaginatedResponse
 from app.database.models import WorkItem
 from app.database.repository import WorkqueueRepository
 from app.enums import WorkItemStatus
+
+logger = logging.getLogger(__name__)
 
 
 class WorkqueueService:
@@ -39,3 +42,17 @@ class WorkqueueService:
         return await self.repository.get_workitem_count(
             workqueue_id, status=WorkItemStatus.NEW
         )
+
+    async def auto_clean_workqueues(self) -> None:
+        """Delete old completed/failed workitems from workqueues with auto-clean enabled."""
+        workqueues = await self.repository.get_auto_clean_workqueues()
+        for workqueue in workqueues:
+            deleted_count = await self.repository.clear_terminal_items_older_than(
+                workqueue.id, workqueue.auto_clean_max_age_days
+            )
+            if deleted_count > 0:
+                logger.info(
+                    f"Auto-clean deleted {deleted_count} workitems from "
+                    f"workqueue '{workqueue.name}' (id={workqueue.id}) older than "
+                    f"{workqueue.auto_clean_max_age_days} days"
+                )

--- a/backend/tests/test_workqueue.py
+++ b/backend/tests/test_workqueue.py
@@ -1,8 +1,13 @@
+from datetime import datetime, timedelta
+
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select, update
 
-from app.database.models import WorkItem, Workqueue
+from app.database.models import AuditLog, WorkItem, Workqueue
+from app.database.repository import WorkqueueRepository
 from app.enums import WorkItemStatus
+from app.services import WorkqueueService
 
 from . import generate_basic_data  # noqa: F401
 
@@ -388,3 +393,158 @@ async def test_get_workitems_by_reference_in_workqueue_with_status_filter(
 
     data = response.json()
     assert len(data) == 0
+
+
+async def test_create_workqueue_with_auto_clean(
+    session: AsyncSession, client: AsyncClient
+):
+    await generate_basic_data(session)
+
+    response = await client.post(
+        "/workqueues/",
+        json={
+            "name": "Auto-clean workqueue",
+            "description": "Queue with auto-clean",
+            "enabled": True,
+            "auto_clean_max_age_days": 30,
+        },
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["auto_clean_max_age_days"] == 30
+
+    workqueue = await session.get(Workqueue, 3)
+    assert workqueue.auto_clean_max_age_days == 30
+
+
+async def test_update_workqueue_auto_clean(session: AsyncSession, client: AsyncClient):
+    await generate_basic_data(session)
+
+    # Default is disabled
+    response = await client.get("/workqueues/1")
+    assert response.json()["auto_clean_max_age_days"] is None
+
+    # Enable auto-clean
+    response = await client.put(
+        "/workqueues/1",
+        json={
+            "name": "Workqueue",
+            "description": "Queue for unittest",
+            "enabled": True,
+            "auto_clean_max_age_days": 14,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["auto_clean_max_age_days"] == 14
+
+    # Disable again
+    response = await client.put(
+        "/workqueues/1",
+        json={
+            "name": "Workqueue",
+            "description": "Queue for unittest",
+            "enabled": True,
+            "auto_clean_max_age_days": None,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["auto_clean_max_age_days"] is None
+
+
+async def test_workqueue_auto_clean_validation(
+    session: AsyncSession, client: AsyncClient
+):
+    await generate_basic_data(session)
+
+    for invalid_value in (0, -1):
+        response = await client.put(
+            "/workqueues/1",
+            json={
+                "name": "Workqueue",
+                "description": "Queue for unittest",
+                "enabled": True,
+                "auto_clean_max_age_days": invalid_value,
+            },
+        )
+        assert response.status_code == 422
+
+
+async def test_auto_clean_workqueues(session: AsyncSession, client: AsyncClient):
+    await generate_basic_data(session)
+
+    # Enable auto-clean on workqueue 1 (30 days)
+    await session.execute(
+        update(Workqueue).where(Workqueue.id == 1).values(auto_clean_max_age_days=30)
+    )
+
+    # Backdate all items in the fixture (NEW, IN_PROGRESS, COMPLETED, FAILED,
+    # PENDING_USER_ACTION) past the cutoff
+    old_date = datetime.now() - timedelta(days=40)
+    await session.execute(update(WorkItem).values(updated_at=old_date))
+
+    # Add a fresh COMPLETED item that must survive
+    session.add(
+        WorkItem(
+            status=WorkItemStatus.COMPLETED,
+            data={},
+            reference="Fresh item",
+            locked=False,
+            workqueue_id=1,
+        )
+    )
+
+    # Audit log referencing the old COMPLETED item (id 3)
+    session.add(
+        AuditLog(
+            event_timestamp=datetime.now(),
+            session_id=1,
+            workitem_id=3,
+            message="Log for completed item",
+            created_at=datetime.now(),
+        )
+    )
+    await session.commit()
+
+    service = WorkqueueService(WorkqueueRepository(session))
+    await service.auto_clean_workqueues()
+    session.expire_all()
+
+    # Old COMPLETED (3) and FAILED (4) deleted
+    assert await session.get(WorkItem, 3) is None
+    assert await session.get(WorkItem, 4) is None
+
+    # Old non-terminal items survive
+    assert (await session.get(WorkItem, 1)).status == WorkItemStatus.NEW
+    assert (await session.get(WorkItem, 2)).status == WorkItemStatus.IN_PROGRESS
+    assert (await session.get(WorkItem, 5)).status == WorkItemStatus.PENDING_USER_ACTION
+
+    # Fresh COMPLETED item survives
+    assert (await session.get(WorkItem, 6)).status == WorkItemStatus.COMPLETED
+
+    # Audit log survives with its workitem link severed
+    audit_log = (
+        await session.scalars(
+            select(AuditLog).where(AuditLog.message == "Log for completed item")
+        )
+    ).first()
+    assert audit_log is not None
+    assert audit_log.workitem_id is None
+
+
+async def test_auto_clean_skips_workqueues_without_setting(
+    session: AsyncSession, client: AsyncClient
+):
+    await generate_basic_data(session)
+
+    # No workqueue has auto-clean enabled; backdate everything
+    old_date = datetime.now() - timedelta(days=400)
+    await session.execute(update(WorkItem).values(updated_at=old_date))
+    await session.commit()
+
+    service = WorkqueueService(WorkqueueRepository(session))
+    await service.auto_clean_workqueues()
+    session.expire_all()
+
+    response = await client.get("/workqueues/1/items")
+    assert response.json()["total_items"] == 5

--- a/backend/tests/test_workqueue.py
+++ b/backend/tests/test_workqueue.py
@@ -25,6 +25,7 @@ async def test_get_workqueues_information(session: AsyncSession, client: AsyncCl
     queue = data[0]
     assert queue["name"] == "Workqueue"
     assert queue["enabled"] is True
+    assert queue["auto_clean_max_age_days"] is None
     assert queue["new"] == 1
     assert queue["in_progress"] == 1
     assert queue["completed"] == 1

--- a/frontend/src/components/WorkqueueForm.vue
+++ b/frontend/src/components/WorkqueueForm.vue
@@ -32,9 +32,47 @@
       <div class="w-1/5 lg:w-1/6"></div>
       <div class="w-full">
         <label class="cursor-pointer flex items-center space-x-2">
-          <input type="checkbox" class="checkbox checkbox-primary" v-model="editedWorkqueue.enabled" id="enabled" />
+          <input
+            type="checkbox"
+            class="checkbox checkbox-primary"
+            v-model="editedWorkqueue.enabled"
+            id="enabled"
+          />
           <span>Enabled</span>
         </label>
+      </div>
+    </div>
+
+    <!-- Auto-Clean -->
+    <div class="flex items-center mb-3">
+      <div class="w-1/5 lg:w-1/6"></div>
+      <div class="w-full">
+        <label class="cursor-pointer flex items-center space-x-2">
+          <input
+            type="checkbox"
+            class="checkbox checkbox-primary"
+            v-model="autoCleanEnabled"
+            id="auto-clean"
+          />
+          <span>Auto-clean old items</span>
+        </label>
+      </div>
+    </div>
+    <div class="flex items-center mb-3" v-if="autoCleanEnabled">
+      <label for="auto-clean-days" class="w-1/5 lg:w-1/6 font-semibold">Max age (days):</label>
+      <div class="w-full">
+        <input
+          type="number"
+          class="input input-bordered w-full"
+          v-model.number="autoCleanDays"
+          id="auto-clean-days"
+          min="1"
+          required
+        />
+        <p class="text-sm opacity-70 mt-1">
+          Completed and failed items older than this are deleted automatically. New and in-progress
+          items are never deleted.
+        </p>
       </div>
     </div>
 
@@ -42,7 +80,14 @@
     <div class="flex justify-end space-x-2 mt-4">
       <button type="submit" class="btn btn-primary">Save</button>
       <button type="button" @click="cancelEdit" class="btn">Cancel</button>
-      <button type="button" @click="deleteWorkqueue" class="btn btn-error" v-if="editedWorkqueue.id">Delete</button>
+      <button
+        type="button"
+        @click="deleteWorkqueue"
+        class="btn btn-error"
+        v-if="editedWorkqueue.id"
+      >
+        Delete
+      </button>
     </div>
   </form>
 </template>
@@ -50,8 +95,7 @@
 <script>
 export default {
   name: 'WorkqueueForm',
-  components: {
-  },
+  components: {},
   props: {
     workqueue: {
       type: Object,
@@ -61,24 +105,34 @@ export default {
   data() {
     return {
       editedWorkqueue: { ...this.workqueue },
+      autoCleanEnabled: this.workqueue.auto_clean_max_age_days != null,
+      autoCleanDays: this.workqueue.auto_clean_max_age_days ?? 30
     }
   },
   methods: {
     saveWorkqueue() {
+      this.editedWorkqueue.auto_clean_max_age_days = this.autoCleanEnabled
+        ? Number(this.autoCleanDays)
+        : null
       this.$emit('save', this.editedWorkqueue)
     },
     cancelEdit() {
       this.$emit('cancel', this.editedWorkqueue)
-      this.editedWorkqueue = { ...this.workqueue }
+      this.resetForm()
     },
     deleteWorkqueue() {
       this.$emit('delete', this.editedWorkqueue)
+    },
+    resetForm() {
+      this.editedWorkqueue = { ...this.workqueue }
+      this.autoCleanEnabled = this.workqueue.auto_clean_max_age_days != null
+      this.autoCleanDays = this.workqueue.auto_clean_max_age_days ?? 30
     }
   },
   watch: {
     workqueue: {
       handler() {
-        this.editedWorkqueue = { ...this.workqueue }
+        this.resetForm()
       },
       deep: true
     }

--- a/frontend/src/components/WorkqueueInfo.vue
+++ b/frontend/src/components/WorkqueueInfo.vue
@@ -12,6 +12,13 @@
         <dl class="grid grid-cols-5 gap-x-2">
           <dt class="col-span-2 font-semibold mb-2">Enabled:</dt>
           <dd class="col-span-3 mb-2">{{ workqueue.enabled ? 'Yes' : 'No' }}</dd>
+          <dt class="col-span-2 font-semibold mb-2">Auto-clean:</dt>
+          <dd class="col-span-3 mb-2">
+            <template v-if="workqueue.auto_clean_max_age_days != null">
+              After {{ workqueue.auto_clean_max_age_days }} days
+            </template>
+            <template v-else>Disabled</template>
+          </dd>
           <dt class="col-span-2 font-semibold mb-2">Last changed:</dt>
           <dd class="col-span-3 mb-2">{{ $formatDateTime(workqueue.updated_at) }}</dd>
         </dl>

--- a/frontend/src/components/WorkqueueItem.vue
+++ b/frontend/src/components/WorkqueueItem.vue
@@ -13,6 +13,15 @@
     </td>
     <td class="text-center p-0">
       <router-link :to="{ name: 'workqueue.detail', params: { id: workqueue.id } }"
+        class="block px-4 py-3 no-underline text-inherit">
+        <span v-if="workqueue.auto_clean_max_age_days != null" :title="`Completed and failed items older than ${workqueue.auto_clean_max_age_days} days are deleted automatically`">
+          {{ workqueue.auto_clean_max_age_days }} days
+        </span>
+        <span v-else class="text-base-content/40" title="Auto-clean disabled">—</span>
+      </router-link>
+    </td>
+    <td class="text-center p-0">
+      <router-link :to="{ name: 'workqueue.detail', params: { id: workqueue.id } }"
         class="block px-4 py-3 no-underline text-inherit">{{ workqueue.in_progress }}</router-link>
     </td>
     <td class="text-center p-0">

--- a/frontend/src/components/WorkqueuesTable.vue
+++ b/frontend/src/components/WorkqueuesTable.vue
@@ -4,6 +4,7 @@
       <tr>
         <th>Name</th>
         <th class="text-center">Enabled</th>
+        <th class="text-center">Auto-clean</th>
         <th class="text-center">In progress</th>
         <th class="text-center">New</th>
         <th class="text-center">Pending user</th>


### PR DESCRIPTION
## Summary
- Adds optional `auto_clean_max_age_days` setting per workqueue (NULL = disabled, default)
- Scheduler housekeeping deletes COMPLETED/FAILED workitems whose `updated_at` is older than the configured age, throttled to at most once per hour
- NEW / IN_PROGRESS / PENDING_USER_ACTION items are never deleted
- Audit logs are preserved: `auditlog.workitem_id` has `ON DELETE SET NULL`, so log rows survive with the workitem link severed
- Frontend: `WorkqueueForm.vue` gets an "Auto-clean old items" checkbox that reveals a required max-age (days) input with helper text; unchecking sends `null` to disable

## Changes
- Migration `e7c1f0a2b9d4`: nullable `auto_clean_max_age_days` integer column on `workqueue`
- `WorkqueueRepository`: `get_auto_clean_workqueues()` and `clear_terminal_items_older_than()` (returns deleted count)
- `WorkqueueService.auto_clean_workqueues()`: iterates enabled queues, logs deleted counts
- `AutomationScheduler`: hourly-throttled call in the housekeeping block
- Schemas: `auto_clean_max_age_days` on `WorkqueueCreate`/`WorkqueueUpdate` with `ge=1` validation

## Testing
- 165 backend tests pass (`uv run pytest`), including new tests: create/update roundtrip, 0/negative rejected with 422, auto-clean deletes only old terminal items, queues without the setting untouched, audit log survives with `workitem_id` nulled
- Migration exercised up and down on real PostgreSQL by the test harness
- Frontend eslint + production build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)