### PR TITLE
feat: encrypt credential username and password at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,23 @@ POSTGRES_USER=ats_user
 POSTGRES_PASSWORD=ats_password
 POSTGRES_DB=ats
 
+# ─── Security ──────────────────────────────────────
+# Encrypts credential usernames and passwords at rest in the database.
+# Any non-empty string works as the key; use a long random value.
+# Generate one with:
+#   python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+# or:
+#   openssl rand -base64 32
+#
+# Optional. Leave unset to store credentials as plaintext (the UI will
+# flag them as "unencrypted"). Existing plaintext credentials are
+# encrypted the next time they are saved after a key is set.
+#
+# IMPORTANT: Back up this key. If it is lost, encrypted credentials
+# cannot be recovered and must be re-entered. Changing the key has the
+# same effect. Do not commit the .env file to version control.
+#ENCRYPTION_KEY=
+
 # ─── Workers ──────────────────────────────────────
 ATS_TOKEN=                          # Leave blank for development
 ATS_URL=http://api:8000             # Internal Docker network URL

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Automation Server allows you to build, run and monitor automations written in py
 - **Audit your automations:** Built-in logging and integration with Pythons logging system provides a clear audit-trail. All logs are grouped by their sessions and associated workitems allowing for ease if access and operations.
 - **Templates for automations:** Automation Server provides a framework for interacting with the server from your processes. There is also a [template](https://github.com/odense-rpa/process-template) to get you started.
 - **Isolated execution:** Each worker runs a single automation at the time and it is isolated in it's private environment, thus ensuring stability and package integrity.
+- **Secure credential storage:** Store credentials for your automations centrally, encrypted at rest with an optional server-side encryption key.
 
 ## Get started
 

--- a/backend/app/api/v1/credentials_router.py
+++ b/backend/app/api/v1/credentials_router.py
@@ -6,7 +6,15 @@ from app.database.unit_of_work import AbstractUnitOfWork
 
 from . import error_descriptions
 from .dependencies import get_unit_of_work, resolve_access_token
-from .schemas import CredentialCreate, CredentialUpdate
+from .schemas import CredentialCreate, CredentialRead, CredentialUpdate
+
+
+def to_credential_read(
+    credential: Credential, unencrypted_ids: set[int]
+) -> CredentialRead:
+    return CredentialRead(
+        **credential.model_dump(), encrypted=credential.id not in unencrypted_ids
+    )
 
 # Dependency Injection local to this router
 
@@ -40,20 +48,24 @@ async def get_credentials(
     include_deleted: bool = False,
     uow: AbstractUnitOfWork = Depends(get_unit_of_work),
     token: AccessToken = Depends(resolve_access_token),
-) -> list[Credential]:
+) -> list[CredentialRead]:
     async with uow:
         result = await uow.credentials.get_all(include_deleted)
+        unencrypted_ids = await uow.credentials.get_unencrypted_ids()
 
         result.sort(key=lambda x: x.name)
-        return result
+        return [to_credential_read(c, unencrypted_ids) for c in result]
 
 
 @router.get("/{credential_id}", responses=RESPONSE_STATES)
-async def get_credential(
+async def read_credential(
     credential: Credential = Depends(get_credential),
+    uow: AbstractUnitOfWork = Depends(get_unit_of_work),
     token: AccessToken = Depends(resolve_access_token),
-) -> Credential:
-    return credential
+) -> CredentialRead:
+    async with uow:
+        unencrypted_ids = await uow.credentials.get_unencrypted_ids()
+        return to_credential_read(credential, unencrypted_ids)
 
 
 @router.get("/by_name/{credential_name}", responses=RESPONSE_STATES)

--- a/backend/app/api/v1/schemas.py
+++ b/backend/app/api/v1/schemas.py
@@ -157,6 +157,19 @@ class CredentialUpdate(CredentialCreate):
     pass
 
 
+class CredentialRead(BaseModel):
+    id: int
+    name: str
+    data: Optional[Dict] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    deleted: bool
+    created_at: datetime
+    updated_at: datetime
+    # True when username and password are stored encrypted at rest
+    encrypted: bool
+
+
 class ResourceCreate(BaseModel):
     name: str
     fqdn: str

--- a/backend/app/database/crypto.py
+++ b/backend/app/database/crypto.py
@@ -1,0 +1,78 @@
+"""Application-level encryption for sensitive database columns.
+
+Encryption is opt-in: when ``settings.encryption_key`` is unset, values are
+stored and returned as plaintext. When a key is configured, values are
+encrypted on write with a ``enc:v1:`` prefix; reads accept both encrypted
+and plaintext values, so existing rows keep working after a key is added.
+"""
+
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet, InvalidToken
+from sqlalchemy import String
+from sqlalchemy.types import TypeDecorator
+
+from app.config import settings
+
+ENCRYPTION_PREFIX = "enc:v1:"
+
+_UNSET_VALUES = ("", "set me in the env file")
+
+
+class EncryptionKeyError(Exception):
+    """An encrypted value cannot be decrypted with the configured key."""
+
+
+def is_configured() -> bool:
+    """Return True when an encryption key is set."""
+    return settings.encryption_key not in _UNSET_VALUES
+
+
+def _fernet() -> Fernet:
+    digest = hashlib.sha256(settings.encryption_key.encode()).digest()
+    return Fernet(base64.urlsafe_b64encode(digest))
+
+
+def encrypt(value: str | None) -> str | None:
+    """Encrypt a value if a key is configured, otherwise pass it through."""
+    if value is None or value == "" or not is_configured():
+        return value
+    return ENCRYPTION_PREFIX + _fernet().encrypt(value.encode()).decode()
+
+
+def decrypt(value: str | None) -> str | None:
+    """Decrypt a value carrying the encryption prefix; pass plaintext through.
+
+    Raises:
+        EncryptionKeyError: The value is encrypted but no key is configured,
+            or the configured key does not match.
+    """
+    if value is None or not value.startswith(ENCRYPTION_PREFIX):
+        return value
+
+    if not is_configured():
+        raise EncryptionKeyError(
+            "Encrypted value found but no encryption key is configured"
+        )
+
+    token = value.removeprefix(ENCRYPTION_PREFIX)
+    try:
+        return _fernet().decrypt(token.encode()).decode()
+    except InvalidToken as exc:
+        raise EncryptionKeyError(
+            "Encrypted value could not be decrypted with the configured key"
+        ) from exc
+
+
+class EncryptedStr(TypeDecorator):
+    """String column encrypted at rest when an encryption key is configured."""
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        return encrypt(value)
+
+    def process_result_value(self, value, dialect):
+        return decrypt(value)

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -8,6 +8,7 @@ from sqlmodel import JSON, Column, Field, Relationship, SQLModel
 from typing_extensions import Self
 
 import app.enums as enums
+from app.database.crypto import EncryptedStr
 
 
 class Base(SQLModel):
@@ -18,8 +19,8 @@ class Credential(Base, table=True):
     id: int | None = Field(default=None, primary_key=True)
     name: str = Field(unique=True)
     data: typing.Dict = Field(default={}, sa_type=JSONB)
-    username: str | None = Field()
-    password: str | None = Field()
+    username: str | None = Field(sa_type=EncryptedStr)
+    password: str | None = Field(sa_type=EncryptedStr)
     deleted: bool = False
     created_at: datetime = Field(default_factory=lambda: datetime.now())
     updated_at: datetime = Field(default_factory=lambda: datetime.now())

--- a/backend/app/database/repository/credential_repository.py
+++ b/backend/app/database/repository/credential_repository.py
@@ -1,6 +1,10 @@
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import select
 
+from app.database import crypto
+from app.database.crypto import ENCRYPTION_PREFIX
 from app.database.models import Credential
 
 from .database_repository import AbstractRepository, DatabaseRepository
@@ -14,9 +18,41 @@ class CredentialRepository(DatabaseRepository[Credential]):
     def __init__(self, session: AsyncSession) -> None:
         super().__init__(Credential, session)
 
+    async def update(self, instance: Credential, data: dict) -> Credential:
+        for field, value in data.items():
+            setattr(instance, field, value)
+
+        # Unchanged values are not marked dirty, so SQLAlchemy would skip
+        # their columns on UPDATE and leave pre-key plaintext in place.
+        # Force a rewrite so saving a credential always encrypts it.
+        if crypto.is_configured():
+            for field in ("username", "password"):
+                if getattr(instance, field):
+                    flag_modified(instance, field)
+
+        return await super().update(instance, {})
+
     async def get_by_name(self, name: str) -> Credential:
         return (
             await self.session.scalars(
                 select(Credential).filter(Credential.name == name)
             )
         ).first()
+
+    async def get_unencrypted_ids(self) -> set[int]:
+        """Return ids of credentials whose username or password is stored as plaintext.
+
+        Uses raw SQL to read the stored values directly, bypassing the
+        EncryptedStr type decorator.
+        """
+        result = await self.session.execute(
+            text(
+                "SELECT id FROM credential"
+                " WHERE (username IS NOT NULL AND username <> ''"
+                "        AND username NOT LIKE :prefix)"
+                "    OR (password IS NOT NULL AND password <> ''"
+                "        AND password NOT LIKE :prefix)"
+            ),
+            {"prefix": f"{ENCRYPTION_PREFIX}%"},
+        )
+        return {row[0] for row in result}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "sqlmodel>0.0.16,<1.0",
     "uvicorn>=0.32.1,<1.0",
     "greenlet>=3.1.1",
+    "cryptography>=49.0.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_credentials.py
+++ b/backend/tests/test_credentials.py
@@ -1,7 +1,9 @@
 from httpx import AsyncClient
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.database.models as models
+from app.config import settings
 
 from . import generate_basic_data  # noqa: F401
 
@@ -183,6 +185,121 @@ async def test_create_credential_with_invalid_json_data(
     )
 
     assert response.status_code == 422
+
+
+async def test_credential_encrypted_at_rest(
+    session: AsyncSession, client: AsyncClient, monkeypatch
+):
+    monkeypatch.setattr(settings, "encryption_key", "test-key")
+
+    response = await client.post(
+        "/credentials/",
+        json={
+            "name": "Encrypted credential",
+            "username": "Encrypted username",
+            "password": "Encrypted password",
+        },
+    )
+    assert response.status_code == 200
+    credential_id = response.json()["id"]
+
+    # The API returns decrypted values and reports the credential as encrypted
+    response = await client.get(f"/credentials/{credential_id}")
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["username"] == "Encrypted username"
+    assert data["password"] == "Encrypted password"
+    assert data["encrypted"] is True
+
+    # The stored values are ciphertext
+    row = (
+        await session.execute(
+            text("SELECT username, password FROM credential WHERE id = :id"),
+            {"id": credential_id},
+        )
+    ).one()
+
+    assert row[0].startswith("enc:v1:")
+    assert row[1].startswith("enc:v1:")
+
+
+async def test_credential_unencrypted_flag(
+    session: AsyncSession, client: AsyncClient, monkeypatch
+):
+    monkeypatch.setattr(settings, "encryption_key", "set me in the env file")
+
+    await generate_basic_data(session)
+
+    response = await client.get("/credentials/")
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data[0]["encrypted"] is False
+
+    response = await client.get("/credentials/1")
+    assert response.json()["encrypted"] is False
+
+
+async def test_credential_mixed_encryption_flags(
+    session: AsyncSession, client: AsyncClient, monkeypatch
+):
+    # Existing credential saved without a key stays plaintext
+    monkeypatch.setattr(settings, "encryption_key", "set me in the env file")
+    await generate_basic_data(session)
+
+    # New credential created after a key is configured is encrypted
+    monkeypatch.setattr(settings, "encryption_key", "test-key")
+    response = await client.post(
+        "/credentials/",
+        json={
+            "name": "Encrypted credential",
+            "username": "Encrypted username",
+            "password": "Encrypted password",
+        },
+    )
+    assert response.status_code == 200
+
+    response = await client.get("/credentials/")
+    flags = {c["name"]: c["encrypted"] for c in response.json()}
+
+    assert flags["Secret credential"] is False
+    assert flags["Encrypted credential"] is True
+
+
+async def test_credential_encrypts_on_save_with_unchanged_values(
+    session: AsyncSession, client: AsyncClient, monkeypatch
+):
+    # Credential created before a key was configured is stored as plaintext
+    monkeypatch.setattr(settings, "encryption_key", "set me in the env file")
+    await generate_basic_data(session)
+
+    # Saving it unchanged after a key is configured must encrypt it
+    monkeypatch.setattr(settings, "encryption_key", "test-key")
+    response = await client.put(
+        "/credentials/1",
+        json={
+            "name": "Secret credential",
+            "username": "Secret username",
+            "password": "My secret password",
+        },
+    )
+    assert response.status_code == 200
+
+    row = (
+        await session.execute(
+            text("SELECT username, password FROM credential WHERE id = 1")
+        )
+    ).one()
+
+    assert row[0].startswith("enc:v1:")
+    assert row[1].startswith("enc:v1:")
+
+    response = await client.get("/credentials/1")
+    data = response.json()
+    assert data["username"] == "Secret username"
+    assert data["password"] == "My secret password"
+    assert data["encrypted"] is True
 
 
 async def test_create_credential_with_empty_json_data(

--- a/backend/tests/test_crypto.py
+++ b/backend/tests/test_crypto.py
@@ -1,0 +1,62 @@
+import pytest
+
+from app.config import settings
+from app.database import crypto
+
+
+def test_is_configured_false_for_unset_values(monkeypatch):
+    monkeypatch.setattr(settings, "encryption_key", "set me in the env file")
+    assert crypto.is_configured() is False
+
+    monkeypatch.setattr(settings, "encryption_key", "")
+    assert crypto.is_configured() is False
+
+
+def test_passthrough_without_key(monkeypatch):
+    monkeypatch.setattr(settings, "encryption_key", "set me in the env file")
+
+    assert crypto.encrypt("secret") == "secret"
+    assert crypto.decrypt("secret") == "secret"
+
+
+def test_roundtrip_with_key(monkeypatch):
+    monkeypatch.setattr(settings, "encryption_key", "test-key")
+
+    token = crypto.encrypt("secret")
+
+    assert token != "secret"
+    assert token.startswith(crypto.ENCRYPTION_PREFIX)
+    assert crypto.decrypt(token) == "secret"
+
+
+def test_none_and_empty_values_pass_through(monkeypatch):
+    monkeypatch.setattr(settings, "encryption_key", "test-key")
+
+    assert crypto.encrypt(None) is None
+    assert crypto.encrypt("") == ""
+    assert crypto.decrypt(None) is None
+    assert crypto.decrypt("") == ""
+
+
+def test_plaintext_passes_through_with_key(monkeypatch):
+    monkeypatch.setattr(settings, "encryption_key", "test-key")
+
+    assert crypto.decrypt("legacy plaintext") == "legacy plaintext"
+
+
+def test_decrypt_without_key_raises(monkeypatch):
+    monkeypatch.setattr(settings, "encryption_key", "test-key")
+    token = crypto.encrypt("secret")
+
+    monkeypatch.setattr(settings, "encryption_key", "set me in the env file")
+    with pytest.raises(crypto.EncryptionKeyError):
+        crypto.decrypt(token)
+
+
+def test_decrypt_with_wrong_key_raises(monkeypatch):
+    monkeypatch.setattr(settings, "encryption_key", "test-key")
+    token = crypto.encrypt("secret")
+
+    monkeypatch.setattr(settings, "encryption_key", "another-key")
+    with pytest.raises(crypto.EncryptionKeyError):
+        crypto.decrypt(token)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -86,6 +86,7 @@ dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "cronsim" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "greenlet" },
     { name = "httpx" },
@@ -112,6 +113,7 @@ requires-dist = [
     { name = "alembic", specifier = ">1.0.0,<2.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "cronsim" },
+    { name = "cryptography", specifier = ">=49.0.0" },
     { name = "fastapi", specifier = ">0.110.0,<1.0" },
     { name = "greenlet", specifier = ">=3.1.1" },
     { name = "httpx", specifier = "<1.0" },
@@ -345,6 +347,56 @@ version = "2.7"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     environment:
       TZ: ${TZ:-UTC}
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
     networks:
       - app-network
     restart: unless-stopped

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -37,3 +37,7 @@ uv run alembic upgrade head
 ```
 
 Models are defined in `backend/app/database/models.py` using SQLModel, which combines SQLAlchemy and Pydantic.
+
+### Credential encryption
+
+When `ENCRYPTION_KEY` is set, credential usernames and passwords are encrypted at rest using Fernet (AES-128-CBC with HMAC). The implementation lives in `backend/app/database/crypto.py` as a SQLAlchemy type decorator, so encryption and decryption happen transparently at the column level — services, repositories, and the API work with plaintext values. Encrypted values carry an `enc:v1:` prefix in the database; values without the prefix are treated as legacy plaintext and pass through unchanged. See [Configuration](../getting-started/configuration.md) for setup.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -28,6 +28,29 @@ POSTGRES_DB=automation
 
 Credentials for the PostgreSQL database. In development, the defaults from `.env.example` are fine. In production, use strong, unique values.
 
+## Credential Encryption
+
+```
+ENCRYPTION_KEY=
+```
+
+Encrypts the username and password of stored credentials at rest in the database. Any non-empty string works as the key; use a long random value:
+
+```bash
+python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+The setting is optional:
+
+- **Unset** — credentials are stored as plaintext. The web interface marks them with an "unencrypted" badge.
+- **Set** — credentials are encrypted whenever they are created or saved. Credentials that existed before the key was set remain plaintext until they are saved again; open and save each one to encrypt it.
+
+The API always returns decrypted values to authenticated clients, so workers and automations are unaffected by this setting.
+
+:::warning
+Back up the encryption key. If it is lost or changed, encrypted credentials cannot be recovered and must be re-entered manually.
+:::
+
 ## Workers
 
 ```

--- a/docs/guides/writing-automations.md
+++ b/docs/guides/writing-automations.md
@@ -134,6 +134,8 @@ cred = Credential.get_by_name(ats, "my-system")
 print(cred.username, cred.password)
 ```
 
+Credentials may be [encrypted at rest](../getting-started/configuration.md#credential-encryption) on the server. This is transparent to automations — the API always returns decrypted values.
+
 ### Logging
 
 Standard Python logging is captured automatically and stored against the session. No extra setup needed — just use `logging.getLogger(__name__)` as usual. See [Logging & Audit](./logging-and-audit.md) for more details.

--- a/frontend/src/components/CredentialForm.vue
+++ b/frontend/src/components/CredentialForm.vue
@@ -1,5 +1,11 @@
 <template>
   <form @submit.prevent="saveCredential" v-if="editedCredential" class="space-y-4">
+    <!-- Unencrypted warning -->
+    <div v-if="credential.encrypted === false" class="alert alert-warning">
+      <span>This credential is stored unencrypted. Set an encryption key on the server and save the
+        credential to encrypt it.</span>
+    </div>
+
     <!-- Name Field -->
     <div class="flex items-center">
       <label for="name" class="w-1/5 font-semibold">Name</label>

--- a/frontend/src/components/CredentialItem.vue
+++ b/frontend/src/components/CredentialItem.vue
@@ -2,7 +2,10 @@
   <tr class="hover:bg-base-300">
     <td class="p-0">
       <router-link :to="{ name: 'credential.edit', params: { id: credential.id } }"
-        class="block px-4 py-3 no-underline text-inherit">{{ credential.name }}</router-link>
+        class="block px-4 py-3 no-underline text-inherit">{{ credential.name }}
+        <span v-if="credential.encrypted === false" class="badge badge-warning badge-sm ml-2"
+          title="Username and password are stored unencrypted">unencrypted</span>
+      </router-link>
     </td>
     <td class="p-0">
       <router-link :to="{ name: 'credential.edit', params: { id: credential.id } }"


### PR DESCRIPTION
## Summary

Optional application-level encryption for stored credentials. Set `ENCRYPTION_KEY` on the backend and credential usernames/passwords are encrypted (Fernet) before they reach the database, carrying an `enc:v1:` prefix. Unset, everything behaves exactly as today.

## Design

- **No migration.** Ciphertext fits the existing varchar columns. Plaintext rows from before a key was set pass through on read and are encrypted the next time the credential is saved.
- **Fail loud.** Encrypted value + missing/wrong key raises `EncryptionKeyError` — the API never serves ciphertext as data.
- **Transparent to clients.** Decryption happens in a SQLAlchemy type decorator; the API returns plaintext to authenticated callers. `by_name` (used by workers and automation-server-client) is byte-for-byte unchanged — verified against both consumers.
- **Visibility.** `GET /credentials` and `GET /credentials/{id}` gain an `encrypted` flag; the UI shows an "unencrypted" badge in the list and a warning banner on the edit form.

## Fixes along the way

- `CredentialRepository.update` now force-rewrites username/password: the ORM skips unchanged attributes on UPDATE, so re-saving a credential previously never re-encrypted it.
- Renamed the credential detail handler to `read_credential` — it shadowed the `get_credential` dependency, so update/delete were silently depending on the route handler.

## Testing

- 176 backend tests pass, incl. new: crypto unit tests, ciphertext-at-rest via API, unencrypted/mixed flags, save-unchanged-encrypts regression.
- Verified end-to-end against the running compose stack: raw DB shows ciphertext, API decrypts, worker + client library unaffected.

## Docs

`ENCRYPTION_KEY` wired through docker-compose, documented in `.env.example`, configuration guide, backend architecture, writing-automations guide, README feature list. Key loss = credentials unrecoverable (documented warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)