### PR TITLE
ci: point nightly prerelease at main instead of retired development branch

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -155,7 +155,7 @@ jobs:
           SHORT_SHA="${{ needs.check-changes.outputs.short_sha }}"
           DATE_TAG="${{ steps.date.outputs.tag }}"
           gh release create nightly \
-            --target development \
+            --target main \
             --title "Nightly Build ($DATE_TAG)" \
             --prerelease \
             --notes "$(cat <<NOTES


### PR DESCRIPTION
The nightly workflow's `gh release create` step still passed `--target development`, a leftover from before the trunk-based migration in 0.4.1. All checkout steps in the same workflow already use `main`; this aligns the release target.

Fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)