### PR TITLE
fix: dispatch empty-requirements processes to any resource; fail unsupported target_type loudly

### DIFF
--- a/backend/app/scheduler/utils.py
+++ b/backend/app/scheduler/utils.py
@@ -37,9 +37,10 @@ def find_best_resource(
         resources: List of available resources
 
     Returns:
-        Best matching resource or None if no match found
+        Best matching resource or None if no match found. Empty requirements
+        match any resource.
     """
-    if not requirements or not resources:
+    if not resources:
         return None
 
     session_requirements = parse_capabilities_or_requirements(requirements)

--- a/backend/tests/scheduler/test_utils.py
+++ b/backend/tests/scheduler/test_utils.py
@@ -56,10 +56,19 @@ class TestFindBestResource:
         return resource
 
     def test_find_best_resource_empty_requirements(self):
-        """Test finding resource with empty requirements."""
+        """Empty requirements match any resource."""
         resources = [self.create_mock_resource("python docker")]
         result = find_best_resource("", resources)
-        assert result is None
+        assert result == resources[0]
+
+    def test_find_best_resource_empty_requirements_prefers_fewest_capabilities(self):
+        """Empty requirements steer to the least specialized resource."""
+        resource1 = self.create_mock_resource("python docker finance-vpn")
+        resource2 = self.create_mock_resource("python")
+        resources = [resource1, resource2]
+
+        result = find_best_resource("", resources)
+        assert result == resource2
 
     def test_find_best_resource_no_resources(self):
         """Test finding resource with no available resources."""

--- a/worker/main.py
+++ b/worker/main.py
@@ -87,9 +87,6 @@ if __name__ == "__main__":
                                 token = credentials["password"]
 
                             if process["target_type"] == "python":
-                                
-                                
-                                
                                 _, _ , returncode = python.run_python(
                                     repo_url=process["target_source"],
                                     username=username,
@@ -107,7 +104,10 @@ if __name__ == "__main__":
                                 
                                 if returncode != 0:
                                     raise RuntimeError("Failing session")
-                                
+                            else:
+                                raise RuntimeError(
+                                    f"target_type '{process['target_type']}' is not supported by this worker"
+                                )
 
                             resources.ping_resource(resource["id"])
             except ConnectionError:


### PR DESCRIPTION
## Fixes #26 — empty requirements never dispatched

`find_best_resource` short-circuited to `None` on empty requirements, so processes with a blank requirements field produced sessions stuck in NEW forever, with no error anywhere.

Decision (discussed on #26): empty requirements = **match any resource**. An empty constraint set is a subset of every capability set, so the fix is removing the short-circuit; the existing fewest-capabilities preference still steers generic work away from specialized resources.

- Flipped `test_find_best_resource_empty_requirements` (it asserted the buggy behavior)
- Added a test that empty requirements prefer the least specialized resource

## Fixes #28 — worker silently ignored unsupported target_type

With dispatch-anywhere, a `blue_prism`/`ui_path`/`power_automate_desktop` process can now actually reach a python-only worker, which previously did nothing and let the session complete as if it ran. The worker now raises inside `acquire_session`, marking the session failed with a clear message in the audit log.

## Testing

- `uv run ruff check .` clean
- `uv run pytest` — 177 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)