### PR TITLE
fix: guard worker shutdown against ping thread never starting

### DIFF
--- a/worker/main.py
+++ b/worker/main.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
                 )
                 time.sleep(5)
     finally:
-        if ping_thread.is_alive():
+        if ping_thread is not None and ping_thread.is_alive():
             stop_ping_thread.set()
             ping_thread.join()
         logger.info("Worker stopped")


### PR DESCRIPTION
`worker/main.py` initializes `ping_thread = None` and only starts it after a resource is acquired. If startup fails before that (backend unreachable at boot, bad token), the `finally` block called `ping_thread.is_alive()` on `None`, raising `AttributeError` and masking the original error.

One-line guard: `if ping_thread is not None and ping_thread.is_alive():`

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)