### PR TITLE
fix: make container healthcheck detect database loss

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -67,7 +67,7 @@ EXPOSE 8000
 
 # Add health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD curl -f http://localhost:8000/health/ready || exit 1
 
 # Add metadata labels
 LABEL maintainer="your-email@example.com" \

--- a/backend/app/api/health_router.py
+++ b/backend/app/api/health_router.py
@@ -3,7 +3,7 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as get_version
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -32,10 +32,15 @@ async def health_check() -> Dict[str, Any]:
 
 @router.get("/ready", response_model=Dict[str, Any])
 async def readiness_check(
+    response: Response,
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, Any]:
-    """Readiness check that includes database connectivity."""
-    response = {
+    """Readiness check that includes database connectivity.
+
+    Returns 503 when the database is unreachable so healthchecks and
+    orchestrators can act on the HTTP status alone.
+    """
+    body = {
         "status": "healthy",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "version": APP_VERSION,
@@ -46,9 +51,10 @@ async def readiness_check(
         # Simple database connectivity check
         result = await session.execute(select(1))
         _ = result.first()
-        response["database"] = "connected"
+        body["database"] = "connected"
     except Exception as e:
-        response["status"] = "unhealthy"
-        response["database"] = f"error: {str(e)}"
+        body["status"] = "unhealthy"
+        body["database"] = f"error: {str(e)}"
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
 
-    return response
+    return body

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,52 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.session import get_session
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_health(client: AsyncClient):
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "healthy"
+    assert "version" in data
+    assert "timestamp" in data
+
+
+@pytest.mark.asyncio
+async def test_health_ready_with_database(client: AsyncClient):
+    response = await client.get("/health/ready")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "healthy"
+    assert data["database"] == "connected"
+
+
+@pytest.mark.asyncio
+async def test_health_ready_returns_503_when_database_down(session: AsyncSession):
+    broken_session = AsyncMock(spec=AsyncSession)
+    broken_session.execute.side_effect = ConnectionError("database unreachable")
+
+    async def get_broken_session():
+        yield broken_session
+
+    app.dependency_overrides[get_session] = get_broken_session
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/health/ready")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["status"] == "unhealthy"
+    assert data["database"].startswith("error:")


### PR DESCRIPTION
Two parts, both needed for #30:

1. **`backend/Dockerfile`**: HEALTHCHECK now hits `/health/ready` instead of `/health` (liveness only).
2. **`health_router.py`**: `/health/ready` returned HTTP 200 even with the database down — "unhealthy" appeared only in the body, which `curl -f` cannot act on. It now returns **503** on DB failure, so the Dockerfile change actually does something.

Also adds `tests/test_health.py` — the health router previously had no tests (covers 200 liveness, 200 ready with DB, 503 ready with broken DB session).

Testing: `ruff check` clean, full backend suite 180 passed.

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)