### PR TITLE
feat: guard against silent auth-bypass mode

### DIFF
--- a/backend/app/api/health_router.py
+++ b/backend/app/api/health_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from app.database.models import AccessToken
 from app.database.session import get_session
 
 router = APIRouter(
@@ -20,13 +21,31 @@ except PackageNotFoundError:
     APP_VERSION = "unknown"
 
 
+async def _auth_mode(session: AsyncSession) -> str:
+    """Report whether API authentication is enforced.
+
+    "open" means the access token table is empty, so requests are served
+    without authentication (install/development bootstrap mode).
+    """
+    try:
+        result = await session.execute(
+            select(AccessToken).where(AccessToken.deleted == False).limit(1)  # noqa: E712
+        )
+        return "enforced" if result.first() is not None else "open"
+    except Exception:
+        return "unknown"
+
+
 @router.get("", response_model=Dict[str, Any])
-async def health_check() -> Dict[str, Any]:
+async def health_check(
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
     """Basic health check endpoint."""
     return {
         "status": "healthy",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "version": APP_VERSION,
+        "auth": await _auth_mode(session),
     }
 
 

--- a/backend/app/api/v1/accesstoken_router.py
+++ b/backend/app/api/v1/accesstoken_router.py
@@ -61,6 +61,15 @@ async def delete_access_token(
     if access_token.deleted:
         raise HTTPException(status_code=403, detail="Access Token is deleted")
 
+    active_tokens = await repository.get_all()
+    if len(active_tokens) <= 1:
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot delete the last access token. Create a replacement "
+            "token first — with no tokens the API would run without "
+            "authentication.",
+        )
+
     await repository.delete(access_token)
 
     # Return 204

--- a/backend/app/api/v1/dependencies.py
+++ b/backend/app/api/v1/dependencies.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from datetime import datetime, timedelta
 from typing import Annotated, Optional
 
@@ -126,6 +128,24 @@ def get_paginated_search_params(
     return schemas.PaginatedSearchParams(pagination=pagination, search=search)
 
 
+logger = logging.getLogger(__name__)
+
+_BYPASS_WARNING_INTERVAL_SECONDS = 600
+_last_bypass_warning = 0.0
+
+
+def _warn_auth_bypass() -> None:
+    global _last_bypass_warning
+    now = time.monotonic()
+    if now - _last_bypass_warning >= _BYPASS_WARNING_INTERVAL_SECONDS:
+        _last_bypass_warning = now
+        logger.warning(
+            "No access tokens configured — serving requests WITHOUT "
+            "authentication. Create a token under Administration to "
+            "enforce auth."
+        )
+
+
 async def resolve_access_token(
     token: str = Depends(oauth2_scheme),
     repository: repositories.AccessTokenRepository = Depends(
@@ -136,6 +156,7 @@ async def resolve_access_token(
 
     # If there are no tokens in the system, we assume that we are in either install or development mode.
     if len(tokens) == 0:
+        _warn_auth_bypass()
         return models.AccessToken(
             id=0,
             token="development-token",

--- a/backend/tests/test_accesstokens.py
+++ b/backend/tests/test_accesstokens.py
@@ -80,7 +80,7 @@ async def test_create_and_access_without_token(
 async def test_delete_accesstoken(session: AsyncSession, client: AsyncClient):
     await generate_basic_data(session)
 
-    # Create a new access token
+    # Create two access tokens so one can be deleted
     response = await client.post(
         "/accesstokens",
         json={
@@ -92,10 +92,53 @@ async def test_delete_accesstoken(session: AsyncSession, client: AsyncClient):
     data = response.json()
     access_token = data["access_token"]
 
-    # Delete the access token
+    response = await client.post(
+        "/accesstokens",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={
+            "identifier": "UnusedAccessToken2",
+        },
+    )
+    assert response.status_code == 200
+
+    # Delete the first access token
     response = await client.delete(
         "/accesstokens/1",
         headers={"Authorization": f"Bearer {access_token}"},
     )
 
     assert response.status_code == 204
+
+
+async def test_delete_last_accesstoken_is_blocked(
+    session: AsyncSession, client: AsyncClient
+):
+    await generate_basic_data(session)
+
+    # Create a single access token
+    response = await client.post(
+        "/accesstokens",
+        json={
+            "identifier": "OnlyToken",
+        },
+    )
+    assert response.status_code == 200
+
+    access_token = response.json()["access_token"]
+
+    # Deleting the last active token must be refused, otherwise the API
+    # would fall back to running without authentication
+    response = await client.delete(
+        "/accesstokens/1",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 409
+
+    # Token still works
+    response = await client.get(
+        "/accesstokens/",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -17,6 +17,18 @@ async def test_health(client: AsyncClient):
     assert data["status"] == "healthy"
     assert "version" in data
     assert "timestamp" in data
+    assert data["auth"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_health_auth_enforced_with_token(client: AsyncClient):
+    response = await client.post("/accesstokens", json={"identifier": "HealthToken"})
+    assert response.status_code == 200
+
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["auth"] == "enforced"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,6 +12,14 @@
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">Automation Server</h1>
       </div>
+      <router-link
+        v-if="authOpen"
+        to="/administration"
+        class="badge badge-warning gap-1 mt-2"
+        title="No access tokens configured — the API accepts requests without authentication. Create a token to enforce auth.">
+        <font-awesome-icon :icon="['fas', 'triangle-exclamation']" />
+        auth off
+      </router-link>
       <hr />
       <nav class="mt-6">
         <router-link class="block py-2.5 px-4 rounded hover:bg-white/10" to="/" active-class="bg-white/15"
@@ -65,6 +73,7 @@
 </template>
 <script>
 import AlertFlasher from './components/AlertFlasher.vue';
+import { healthAPI } from '@/services/automationserver';
 
 export default {
   components: {
@@ -74,6 +83,8 @@ export default {
     return {
       isSidebarOpen: false,
       isDark: false,
+      authOpen: false,
+      healthInterval: null,
     };
   },
   watch: {
@@ -93,6 +104,14 @@ export default {
     applyTheme() {
       document.documentElement.setAttribute('data-theme', this.isDark ? 'automation-dark' : 'automation');
     },
+    async checkAuthMode() {
+      try {
+        const health = await healthAPI.getHealth();
+        this.authOpen = health.auth === 'open';
+      } catch {
+        this.authOpen = false;
+      }
+    },
   },
   mounted() {
     const stored = localStorage.getItem('theme-dark');
@@ -109,6 +128,12 @@ export default {
         this.applyTheme();
       }
     });
+
+    this.checkAuthMode();
+    this.healthInterval = setInterval(this.checkAuthMode, 60000);
+  },
+  unmounted() {
+    clearInterval(this.healthInterval);
   },
 };
 </script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,14 +12,6 @@
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">Automation Server</h1>
       </div>
-      <router-link
-        v-if="authOpen"
-        to="/administration"
-        class="badge badge-warning gap-1 mt-2"
-        title="No access tokens configured — the API accepts requests without authentication. Create a token to enforce auth.">
-        <font-awesome-icon :icon="['fas', 'triangle-exclamation']" />
-        auth off
-      </router-link>
       <hr />
       <nav class="mt-6">
         <router-link class="block py-2.5 px-4 rounded hover:bg-white/10" to="/" active-class="bg-white/15"
@@ -35,8 +27,16 @@
         <router-link class="block py-2.5 px-4 rounded hover:bg-white/10" to="/administration"
           active-class="bg-white/15">Administration</router-link>
       </nav>
-      <!-- Dark mode toggle -->
+      <!-- Auth warning + dark mode toggle -->
       <div class="mt-auto pt-6">
+        <router-link
+          v-if="authOpen"
+          to="/administration"
+          class="btn btn-ghost btn-sm gap-2 w-full justify-start text-warning opacity-70 hover:opacity-100"
+          title="No access tokens configured — the API accepts requests without authentication. Create a token to enforce auth.">
+          <font-awesome-icon :icon="['fas', 'triangle-exclamation']" />
+          Auth disabled
+        </router-link>
         <button @click="toggleDarkMode" class="btn btn-ghost btn-sm gap-2 w-full justify-start opacity-70 hover:opacity-100">
           <font-awesome-icon :icon="['fas', isDark ? 'sun' : 'moon']" />
           {{ isDark ? 'Light mode' : 'Dark mode' }}

--- a/frontend/src/services/automationserver.js
+++ b/frontend/src/services/automationserver.js
@@ -429,6 +429,10 @@ const accessTokensApi = {
       const response = await axios.delete(`/accesstokens/${token}`)
       return response.data
     } catch (error) {
+      const detail = error.response?.data?.detail
+      if (typeof detail === 'string') {
+        throw new Error(detail)
+      }
       throw new Error(`Error deleting access token: ${error}`)
     }
   }

--- a/frontend/src/services/automationserver.js
+++ b/frontend/src/services/automationserver.js
@@ -495,8 +495,21 @@ const incidentsAPI = {
   }
 }
 
+// Health API
+const healthAPI = {
+  getHealth: async () => {
+    try {
+      const response = await axios.get(`/health`)
+      return response.data
+    } catch (error) {
+      throw new Error(`Error fetching health: ${error}`)
+    }
+  }
+}
+
 // Export APIs for use in Vue components or elsewhere
 export {
+  healthAPI,
   processesAPI,
   workqueuesAPI,
   credentialsAPI,


### PR DESCRIPTION
The API runs without authentication when the `access_token` table is empty (bootstrap mode). Because `get_all()` filters soft-deleted rows, that state was reachable in production by deleting the last token via the API — instantly opening every endpoint with no signal anywhere.

Changes (per discussion on #31):

1. **Last-token delete guard**: `DELETE /accesstokens/{id}` returns 409 when the target is the last active token. Bypass mode is now only reachable on a fresh install.
2. **`/health` exposes `auth: enforced|open`** (`unknown` if the DB check fails — the liveness endpoint stays tolerant of DB loss).
3. **Throttled backend warning** (once per 10 min) while serving unauthenticated requests.
4. **Frontend navbar badge**: small yellow "auth off" chip under the app title when the API reports open auth, tooltip explains, links to Administration for token creation. Polls `/health` every 60s. No dismissal logic — unobtrusive by design so it stays honest on dev setups.

Tests: existing delete test updated (deleted the only token, now blocked by design); new tests for the 409 guard and both auth states on `/health`. Backend 182 passed, ruff clean; frontend eslint + build clean.

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)